### PR TITLE
docs: update contributor setup to use uv and zensical

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,11 +40,7 @@ Request features on the [Issue Tracker][Issue Tracker].
 
 We recommend using [uv](https://docs.astral.sh/uv/) to manage the project environment.
 
-1. Install `uv` (if needed):
-
-```console
-$ curl -LsSf https://astral.sh/uv/install.sh | sh
-```
+1. Install `uv` (if needed), see [uv installation instructions.](https://docs.astral.sh/uv/getting-started/installation/#installation-methods)
 
 2. Sync the project with development, docs, and testing dependencies:
 
@@ -101,17 +97,11 @@ Your pull request needs to meet the following guidelines for acceptance:
 - Include unit tests.
 - If your changes add functionality, update the documentation accordingly.
 
-To run linting and code formatting checks before committing your change, you can install pre-commit as a Git hook by running one of following commands, depending on your dependencies manager:
+To run linting and code formatting checks before committing your change, install pre-commit hooks and run checks before pushing:
 
 ```console
-# conda or mamba
-$ conda install pre-commit
-```
-
-or
-
-```
-$ pip install pre-commit
+$ uv run pre-commit install
+$ uv run pre-commit run --all-files
 ```
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,24 +38,26 @@ Request features on the [Issue Tracker][Issue Tracker].
 
 ## How to set up your development environment
 
-Install the package with development requirements:
+We recommend using [uv](https://docs.astral.sh/uv/) to manage the project environment.
+
+1. Install `uv` (if needed):
 
 ```console
-$ pip install -e ".[dev]"
+$ curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+2. Sync the project with development, docs, and testing dependencies:
+
+```console
+$ uv sync --extra dev --extra docs --extra testing
 ```
 
 ## How to build the documentation locally
 
-Make sure you have installed the `docs` extras of the package.
-
-```console
-$ pip install -e ".[docs]"
-```
-
 Serve the documentation locally with live reload:
 
 ```console
-$ mkdocs serve
+$ uv run zensical serve
 ```
 
 The documentation will be available at `http://127.0.0.1:8000/`.
@@ -63,7 +65,7 @@ The documentation will be available at `http://127.0.0.1:8000/`.
 To build static documentation files:
 
 ```console
-$ mkdocs build
+$ uv run zensical build
 ```
 
 The built documentation will be in the `site` directory.
@@ -74,13 +76,13 @@ The built documentation will be in the `site` directory.
 1. Install the package with development requirements:
 
 ```console
-$ pip install -e ".[testing]"
+$ uv sync --extra testing
 ```
 
 2. Run the full test suite:
 
 ```console
-$ pytest
+$ uv run pytest
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This means:
 - **Familiar workflows** — If you know Brightway, you already know how to build foreground systems for `optimex`.
 - **Reuse existing models** — Temporalize and optimize a product system you have already built for standard LCA.
 
-> **Tip:** you can also directly re-use temporalized product system models made with [`bw_timex`](https://github.com/brightway-lca/bw_timex), our time-explicit *assessment* framework. 
+> **Tip:** you can also directly re-use temporalized product system models made with [`bw_timex`](https://github.com/brightway-lca/bw_timex), our time-explicit *assessment* framework.
 
 For optimization, `optimex` uses [Pyomo](https://www.pyomo.org), a powerful open-source algebraic modeling language for mathematical programming.
 
@@ -86,7 +86,7 @@ Full documentation, tutorials, and examples are available at **[optimex.readthed
 
 ## Contributing
 
-[Open an Issue](https://github.com/TimoDiepers/optimex/issues) or [Send a Pull Request](https://github.com/TimoDiepers/optimex/pulls) — contributions are welcome.
+[Open an Issue](https://github.com/TimoDiepers/optimex/issues) or [Send a Pull Request](https://github.com/TimoDiepers/optimex/pulls) — contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor setup and workflow.
 
 ## License
 


### PR DESCRIPTION
### Motivation
- Bring the contributor onboarding documentation in line with the repository's current workflow and CI by using `uv` for environment management and `zensical` for documentation builds.
- Make the README point directly to the full contributor guide for setup and workflow details.

### Description
- Replace pip/mkdocs instructions in `CONTRIBUTING.md` with `uv`-based steps including installing `uv` and `uv sync --extra dev --extra docs --extra testing` for environment setup.
- Switch local docs workflow to `uv run zensical serve` and `uv run zensical build` in `CONTRIBUTING.md`.
- Update testing instructions to use `uv sync --extra testing` and `uv run pytest`.
- Add an explicit link in the README Contributing section to `CONTRIBUTING.md` and normalize trailing whitespace.

### Testing
- No automated test suite was executed locally because this PR contains documentation changes only; CI is expected to run the project's test workflow (`uv sync --extra testing` and `uv run pytest`) after push.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef25bf0b30832abd2aa8e8deef049f)