### PR TITLE
Add notebook-friendly _repr_html_ support across core classes

### DIFF
--- a/src/optimex/converter.py
+++ b/src/optimex/converter.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, Field, model_validator
 
+from optimex.html_repr import simple_repr_html
 from optimex.lca_processor import LCADataProcessor
 
 
@@ -333,6 +334,24 @@ class OptimizationModelInputs(BaseModel):
             "specified."
         ),
     )
+
+    def _repr_html_(self) -> str:
+        """Rich HTML representation for Jupyter notebooks."""
+        return simple_repr_html(
+            "OptimizationModelInputs",
+            {
+                "PROCESS": self.PROCESS,
+                "PRODUCT": self.PRODUCT,
+                "SYSTEM_TIME": self.SYSTEM_TIME,
+                "CATEGORY": self.CATEGORY,
+                "demand": self.demand,
+                "foreground_technosphere": self.foreground_technosphere,
+                "foreground_biosphere": self.foreground_biosphere,
+                "foreground_production": self.foreground_production,
+                "background_inventory": self.background_inventory,
+                "characterization": self.characterization,
+            },
+        )
 
     @model_validator(mode="before")
     def check_all_keys(cls, data):
@@ -1083,6 +1102,16 @@ class ModelInputManager:
         previously saved inputs from disk.
         """
         self.model_inputs = None
+
+    def _repr_html_(self) -> str:
+        """Rich HTML representation for Jupyter notebooks."""
+        return simple_repr_html(
+            "ModelInputManager",
+            {
+                "has_model_inputs": self.model_inputs is not None,
+                "model_inputs": self.model_inputs,
+            },
+        )
 
     def parse_from_lca_processor(
         self, lca_processor: LCADataProcessor

--- a/src/optimex/html_repr.py
+++ b/src/optimex/html_repr.py
@@ -1,0 +1,30 @@
+"""Helpers for rich HTML representations in notebooks."""
+
+from html import escape
+from typing import Any, Dict
+
+
+def _format_value(value: Any) -> str:
+    """Format common container values for compact HTML display."""
+    if value is None:
+        return "None"
+    if isinstance(value, (list, tuple, set, dict)):
+        return f"{type(value).__name__}(len={len(value)})"
+    return escape(str(value))
+
+
+def simple_repr_html(title: str, rows: Dict[str, Any]) -> str:
+    """Return a compact two-column HTML summary table."""
+    body = "".join(
+        "<tr>"
+        f"<th style='text-align:left;padding:4px 8px;background:#f6f8fa;'>{escape(str(k))}</th>"
+        f"<td style='padding:4px 8px;'>{_format_value(v)}</td>"
+        "</tr>"
+        for k, v in rows.items()
+    )
+    return (
+        "<div style='font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;'>"
+        f"<div style='font-weight:600;margin:0 0 6px 0;'>{escape(title)}</div>"
+        "<table style='border-collapse:collapse;border:1px solid #d0d7de;'>"
+        f"{body}</table></div>"
+    )

--- a/src/optimex/lca_processor.py
+++ b/src/optimex/lca_processor.py
@@ -25,6 +25,8 @@ from loguru import logger
 from pydantic import BaseModel, Field
 from tqdm import tqdm
 
+from optimex.html_repr import simple_repr_html
+
 
 class MetricEnum(str, Enum):
     """
@@ -38,6 +40,9 @@ class MetricEnum(str, Enum):
     GWP = "GWP"
     CRF = "CRF"
 
+    def _repr_html_(self) -> str:
+        return simple_repr_html("MetricEnum", {"value": self.value})
+
 
 class TemporalResolutionEnum(str, Enum):
     """
@@ -48,6 +53,9 @@ class TemporalResolutionEnum(str, Enum):
     """
 
     year = "year"
+
+    def _repr_html_(self) -> str:
+        return simple_repr_html("TemporalResolutionEnum", {"value": self.value})
 
 
 class CharacterizationMethodConfig(BaseModel):
@@ -89,6 +97,17 @@ class CharacterizationMethodConfig(BaseModel):
         """Indicates whether this is a dynamic characterization method."""
         return self.metric is not None
 
+    def _repr_html_(self) -> str:
+        return simple_repr_html(
+            "CharacterizationMethodConfig",
+            {
+                "category_name": self.category_name,
+                "brightway_method": self.brightway_method,
+                "metric": self.metric,
+                "dynamic": self.dynamic,
+            },
+        )
+
 
 class TemporalConfig(BaseModel):
     """
@@ -124,6 +143,18 @@ class TemporalConfig(BaseModel):
         description="Mapping from database names to their respective reference dates.",
     )
 
+    def _repr_html_(self) -> str:
+        return simple_repr_html(
+            "TemporalConfig",
+            {
+                "start_date": self.start_date,
+                "temporal_resolution": self.temporal_resolution,
+                "time_horizon": self.time_horizon,
+                "fixed_time_horizon": self.fixed_time_horizon,
+                "database_dates": self.database_dates,
+            },
+        )
+
 
 class BackgroundInventoryConfig(BaseModel):
     """
@@ -155,6 +186,17 @@ class BackgroundInventoryConfig(BaseModel):
         "If provided, the tensor will be loaded instead of calculated.",
     )
 
+    def _repr_html_(self) -> str:
+        return simple_repr_html(
+            "BackgroundInventoryConfig",
+            {
+                "cutoff": self.cutoff,
+                "calculation_method": self.calculation_method,
+                "path_to_save": self.path_to_save,
+                "path_to_load": self.path_to_load,
+            },
+        )
+
 
 class LCAConfig(BaseModel):
     """
@@ -177,6 +219,17 @@ class LCAConfig(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
+
+    def _repr_html_(self) -> str:
+        return simple_repr_html(
+            "LCAConfig",
+            {
+                "demand": self.demand,
+                "temporal": self.temporal,
+                "characterization_methods": self.characterization_methods,
+                "background_inventory": self.background_inventory,
+            },
+        )
 
 
 class LCADataProcessor:
@@ -252,6 +305,21 @@ class LCADataProcessor:
         self._prepare_background_inventory()
         self._construct_characterization_tensor()
         self._construct_mapping_matrix()
+
+    def _repr_html_(self) -> str:
+        return simple_repr_html(
+            "LCADataProcessor",
+            {
+                "foreground_db": getattr(self.foreground_db, "name", None),
+                "background_databases": self.background_dbs,
+                "processes": self._processes,
+                "products": self._products,
+                "intermediate_flows": self._intermediate_flows,
+                "elementary_flows": self._elementary_flows,
+                "system_time": self._system_time,
+                "categories": self._category,
+            },
+        )
 
     @property
     def processes(self) -> dict:

--- a/src/optimex/postprocessing.py
+++ b/src/optimex/postprocessing.py
@@ -18,6 +18,8 @@ import numpy as np
 import pandas as pd
 import pyomo.environ as pyo
 
+from optimex.html_repr import simple_repr_html
+
 
 class _EngineeringFormatter(mticker.ScalarFormatter):
     """Y-axis formatter that always shows values as X.X with a 10^n offset.
@@ -43,6 +45,15 @@ class _EngineeringFormatter(mticker.ScalarFormatter):
 
     def _set_format(self):
         self.format = "%1.1f"
+
+    def _repr_html_(self) -> str:
+        return simple_repr_html(
+            "_EngineeringFormatter",
+            {
+                "order_of_magnitude": getattr(self, "orderOfMagnitude", None),
+                "format": getattr(self, "format", None),
+            },
+        )
 
 
 class PostProcessor:
@@ -131,6 +142,18 @@ class PostProcessor:
 
         # Pre-populate cache for code -> name lookups (batch load for performance)
         self._name_cache = self._build_name_cache()
+
+    def _repr_html_(self) -> str:
+        return simple_repr_html(
+            "PostProcessor",
+            {
+                "num_processes": len(self.m.PROCESS),
+                "num_products": len(self.m.PRODUCT),
+                "plot_config": self._plot_config,
+                "color_map": self._color_map,
+                "name_cache": self._name_cache,
+            },
+        )
 
     def _create_color_map(self):
         """


### PR DESCRIPTION
### Motivation
- Improve developer experience by providing compact, styled HTML representations for core objects when inspected in Jupyter notebooks.
- Make configuration, data processor, input manager and post-processing objects easier to explore and debug interactively.
- Provide a small shared helper to keep HTML rendering consistent and safe for common container types.

### Description
- Add a shared helper `simple_repr_html` in `src/optimex/html_repr.py` to build compact two-column HTML summaries and safely format container values.
- Implement `_repr_html_` on `OptimizationModelInputs` and `ModelInputManager` in `src/optimex/converter.py` to show key fields and presence of loaded inputs.
- Add `_repr_html_` implementations for enums, config models, and `LCADataProcessor` in `src/optimex/lca_processor.py` to expose configuration and dataset summaries.
- Add `_repr_html_` to `_EngineeringFormatter` and `PostProcessor` in `src/optimex/postprocessing.py` so plotting-related objects also render nicely in notebooks.

### Testing
- Ran `python -m compileall src/optimex` and compilation completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef39715e58832aa1294340b71cfc00)