### PR TITLE
Simplify Home nav and add Project section in zensical.toml

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -11,8 +11,8 @@ edit_uri = "edit/main/docs/"
 copyright = "Copyright &copy; 2026 Institute of Technical Thermodynamics, RWTH Aachen University"
 
 nav = [
-  { Home = [
-    { Overview = "index.md" },
+  { Home = "index.md" },
+  { Project = [
     { Changelog = "content/changelog.md" },
     { License = "content/license.md" },
     { Contributing = "content/contributing.md" },


### PR DESCRIPTION
### Motivation
- Separate project-level documents from the Home entry to make the top-level navigation clearer and more focused.
- Group changelog, license, contributing, and code-of-conduct pages under a dedicated `Project` section for easier access.

### Description
- Modify `zensical.toml` to make `Home` point directly to `index.md` instead of an `Overview` submenu.
- Add a new top-level `{ Project = [...] }` navigation entry containing `content/changelog.md`, `content/license.md`, `content/contributing.md`, and `content/codeofconduct.md`.
- No other file changes were made.

### Testing
- Built the documentation site with `zensical build` and verified the navigation compiled without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb8048f3c832a8e8eca44439d0cef)